### PR TITLE
Changed the script to force to use python2

### DIFF
--- a/bin/spotify
+++ b/bin/spotify
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import dbus
 import dbus.service


### PR DESCRIPTION
Because this script is only compatible with python2, if the user has also python3 installed in the computer, python will try to run the script with the latest version.

I was trying to use it in Arch and I have that problem (it couldn't load dbus module, print syntax is wrong, ....).

I know nothing about python, so I am sorry in advance if what I've done is kind of dumb, but it made it work in my computer.
