### PR TITLE
Fix notifications

### DIFF
--- a/bin/spotify
+++ b/bin/spotify
@@ -76,8 +76,9 @@ class SpotifyGnome(object):
                     self.initialize_notifications()
             else:
                 self.mediakeys.ReleaseMediaPlayerKeys("Spotify")
-                self.notification.close()
-                Notify.uninit()
+                if ENABLE_NOTIFICATIONS:
+                    self.notification.close()
+                    Notify.uninit()
                 self.loop.quit()
 
     def key_pressed(self, *keys):


### PR DESCRIPTION
A few fixes for my previous patch.  Most notably, my old code waited 2 seconds for Spotify to start before attempting to connect to the `PropertiesChanged` signal.  If Spotify didn't start in time the script crashed.  This patch fixes that by connecting to `PropertiesChanged` in your `name_owner_changed` callback.

Also
- Cleans up notifications on exit
- Handles key errors in the metadata received from `PropertiesChanged`
- Adds a stopped notification
