### PR TITLE
Threaded cover images

### DIFF
--- a/bin/spotify
+++ b/bin/spotify
@@ -163,6 +163,7 @@ class FetchAndUpdateCoverIcon(threading.Thread):
         self.title = title
         self.body = body
         self.notification_lock = notification_lock
+        self.name = "FetchAndUpdateCoverIcon-%f" % time.time()
 
         self.cache_dir = os.path.join(GLib.get_user_cache_dir(), 'spotify-gnome')
 
@@ -181,6 +182,15 @@ class FetchAndUpdateCoverIcon(threading.Thread):
             print(e)
             print "URL was: " + self.icon_url
             icon = "media-playback-start"
+
+        for thread in threading.enumerate():
+            try:
+                current_name, current_time = threading.current_thread().name.split("-")
+                thread_name, thread_time = thread.name.split("-")
+            except ValueError:
+                continue
+            if current_name == thread_name and float(current_time) < float(thread_time):
+                return
 
         with self.notification_lock:
             self.notification.update(self.title, self.body, icon)


### PR DESCRIPTION
This is based on the refactor branch (#11) so may need some rebasing later on if there are changes over there.

As discussed in #9, this adds support for fetching album art in a separate thread, so that there is no lag before a notification is shown when the track changes.

First, the notification icon is set with 'media-playback-start'.  Then, the `FetchAndUpdateCoverIcon` thread is started, downloads or fetches the cover image from the cache, and updates the notification.

To prevent old threads overwriting new ones (i.e. if the user skips through songs quickly), a basic check on the start time of the current thread vs the start time of all other running threads is performed.  However this won't catch the case where an old, long-running thread doesn't finish until after a new, short-running thread has exited - the newer, terminated thread will not show up in the check (because it has terminated), and its notification will be overwritten.

Any suggestions for a better way of doing this?
