### PR TITLE
Added GDMSESSION check to fix non-function Play/Pause key behavior in Ci...

### DIFF
--- a/bin/spotify
+++ b/bin/spotify
@@ -60,7 +60,10 @@ class MediaKeysHandler(Handler):
                     pass
 
                 elif key == "Play":
-                    self.spotify.PlayPause()
+                    if 'cinnamon' == os.getenv('GDMSESSION'):
+                        self.spotify.Play()
+                    else:
+                        self.spotify.PlayPause()
 
                 elif key == "Stop":
                     self.spotify.Stop()


### PR DESCRIPTION
...nnamon.  Prior to update, the Play/Pause button only paused Spotify for a split second and would restart playing.  After pressing Stop, the Play button could not resume playback.
