### PR TITLE
Fixes PlayPause

### DIFF
--- a/bin/spotify
+++ b/bin/spotify
@@ -61,6 +61,9 @@ class MediaKeysHandler(Handler):
 
                 elif key == "Play":
                     self.spotify.PlayPause()
+                    
+                elif key == "Pause":
+                    self.spotify.PlayPause()
 
                 elif key == "Stop":
                     self.spotify.Stop()


### PR DESCRIPTION
Despite having downloaded the player from Spotify itself and checked over all the keybindings available to me through Ubuntu's Keyboard settings, the only media keys that work are the volume ones. After installing your little wrapper, everything but the play/pause button worked. So I started looking through the output logs.

The keyboard I'm using is outputting a `Pause` key hit when I hit the Play/Pause key on my keyboard instead of `Play` or `Play` as written in this code so I added another elseif for Pause so both buttons would simply activate the toggle mechanic since that's what seems to be at the core.

Thanks again for writing this. I've administrated Linux web servers, but this is my first go at a GUI Linux like Ubuntu. So I've got some tinkering to do.
